### PR TITLE
Include exception error in dialogue box

### DIFF
--- a/cfgWindow.py
+++ b/cfgWindow.py
@@ -119,9 +119,9 @@ class ConfigFrame(ttk.Frame):
                 s = serial.Serial(port=self.parent.variables['COMport'][0:4])
                 s.close()              
                 GraphTopLevel(self.parent)
-            except:
+            except Exception as e:
                 #Otherwise the port isn't available, so error out
-                messagebox.showerror(message='COM port not available')
+                messagebox.showerror(message=('COM port not available: ', e))
     
     def aboutButton(self):
         toplvl = tk.Toplevel()


### PR DESCRIPTION
Add the exception in the message dialogue. This way users have a better idea of what's going on when there are errors. An alternative would be to use the logging module to log it to a file or to the console.
