### PR TITLE
Fix opening the serial port in Linux

### DIFF
--- a/cfgWindow.py
+++ b/cfgWindow.py
@@ -19,6 +19,7 @@ import serial.tools.list_ports
 import idlelib.ToolTip as tt
 import pprint
 from defaults import defaults
+import os
 
 class ConfigFrame(ttk.Frame):
     """
@@ -116,12 +117,17 @@ class ConfigFrame(ttk.Frame):
         else:
             try:
                 #Try to open the COM port first to make sure it's available                
-                s = serial.Serial(port=self.parent.variables['COMport'][0:4])
+                if os.name == 'nt':
+                    s = serial.Serial(port=self.parent.variables['COMport'][0:4])
+                else:
+                    first_space = self.parent.variables['COMport'].index(' ')
+                    # Parameters necessary due to https://github.com/pyserial/pyserial/issues/59
+                    s = serial.Serial(port=self.parent.variables['COMport'][0:first_space], rtscts=True, dsrdtr=True)
                 s.close()              
                 GraphTopLevel(self.parent)
-            except:
+            except Exception as e:
                 #Otherwise the port isn't available, so error out
-                messagebox.showerror(message='COM port not available')
+                messagebox.showerror(message=('COM port not available: ', e))
     
     def aboutButton(self):
         toplvl = tk.Toplevel()

--- a/graphWindow.py
+++ b/graphWindow.py
@@ -6,6 +6,7 @@ import sys
 import serial
 import io
 import time
+import os
 
 if sys.version_info[0] < 3:
     #If we're executing with Python 2
@@ -274,13 +275,22 @@ class Graph(ttk.Frame):
         stopbitsdict = {'1':serial.STOPBITS_ONE,
                         '2':serial.STOPBITS_TWO}
         stopbits = stopbitsdict[str(self.root.variables['stopbits'])]
-        port = self.root.variables['COMport'][0:5].strip()
             
         #Open the serial port given the settings, store under the root
-        self.root.ser = serial.Serial(\
-            port=port,\
-            baudrate=str(self.root.variables['baud']),\
-            bytesize=bytesize, parity=parity, stopbits=stopbits, timeout=0.5) 
+        if os.name == 'nt':
+            port = self.root.variables['COMport'][0:5].strip()
+            self.root.ser = serial.Serial(\
+                port=port,\
+                baudrate=str(self.root.variables['baud']),\
+                bytesize=bytesize, parity=parity, stopbits=stopbits, timeout=0.5) 
+        else:
+            first_space = self.root.variables['COMport'].index(' ')
+            port = self.root.variables['COMport'][0:first_space].strip()
+            # Parameters necessary due to https://github.com/pyserial/pyserial/issues/59
+            self.root.ser = serial.Serial(\
+                port=port,\
+                baudrate=str(self.root.variables['baud']),\
+                bytesize=bytesize, parity=parity, stopbits=stopbits, timeout=0.5, rtscts=True, dsrdtr=True) 
         io.DEFAULT_BUFFER_SIZE = 5000
             
         #Purge the buffer of any previous data


### PR DESCRIPTION
With this pull request, and the other two that I sent, I'm able to run the application on Linux.

It's giving me a blank graph, probably because I haven't figured out a way to emulate sending data to a fake serial port (started with the socat utility). But at least the TK application is running, and the ser variable holds a handler to a serial port.
