### PR TITLE
Decode byte array instead of converting it into a String

### DIFF
--- a/graphWindow.py
+++ b/graphWindow.py
@@ -303,7 +303,7 @@ class Graph(ttk.Frame):
         #the buffer until we're below the threshold
         while int(serialqueue(self.root.ser)) >= int(self.root.variables['maxlength']):
             #Read a line
-            val = str(self.root.ser.readline())
+            val = self.root.ser.readline().decode('utf-8')
             val = val.replace('\n', '')
             val = val.replace('\r', '')
                 


### PR DESCRIPTION
The self.root.ser.readline() method returns a byte array. At least with Python 3, the result of converting it into a String with str() is a value like b'1000,1000'.

By decoding the byte array first, we get a valid string that can be used as intended (I assume).

With this last change, I could successfully use the application in Linux :-) with Python 3
